### PR TITLE
add camera rig plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,16 +409,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_boiler"
-version = "0.1.0"
-dependencies = [
- "bevy",
- "derive-new",
- "derive_more",
- "leafwing-input-manager",
-]
-
-[[package]]
 name = "bevy_core"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,6 +2378,16 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "logic_tools"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "derive-new",
+ "derive_more",
+ "leafwing-input-manager",
+]
 
 [[package]]
 name = "mach2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bevy_boiler"
+name = "logic_tools"
 version = "0.1.0"
 edition = "2021"
 
@@ -11,6 +11,7 @@ bevy = { version = "0.13.2", features = [
     # Otherwise you will need to include libbevy_dylib alongside your game if you want it to run. 
     # If you remove the "dynamic" feature, your game executable can run standalone.
     "dynamic_linking",
+    # Create an empty "assets" folder if this prevents the game from running.
     "file_watcher",
 ] }
 derive-new = "0.6.0"

--- a/src/camera_rig.rs
+++ b/src/camera_rig.rs
@@ -1,0 +1,122 @@
+use bevy::{ ecs::system::EntityCommands, prelude::*, render::primitives::Frustum };
+use leafwing_input_manager::{ action_state, prelude::* };
+
+/// Marks the root entity in a camera rig hierarchy.
+#[derive(Component, Debug, Reflect)]
+pub struct CameraRig {
+    pub camera_entity: Entity,
+    pub joint_entity: Entity,
+    pub target: Option<Entity>,
+}
+
+/// Parent of the camera entity, allowing camera zoom and rotation.
+#[derive(Component, Debug, Default, Reflect)]
+pub struct CameraJoint;
+
+/// Marks an entity as the primary camera.
+#[derive(Component, Debug, Default, Reflect)]
+pub struct PrimaryCamera;
+
+/// Spawns a camera rig hierarchy
+///
+/// ```
+/// +-- CameraRig (translation and rotation)
+/// |  +-- CameraJoint (zoom)
+/// |  |  +-- PrimaryCamera
+/// ```
+pub fn spawn_camera_rig(mut commands: Commands) {
+    let mut camera_entity: Entity = Entity::PLACEHOLDER;
+    let mut joint_entity: Entity = Entity::PLACEHOLDER;
+    commands
+        .spawn((
+            InputManagerBundle::with_map(
+                InputMap::new([
+                    (CameraAction::Move, UserInput::from(VirtualDPad::wasd())),
+                    (
+                        CameraAction::Zoom,
+                        UserInput::from(VirtualAxis::vertical_arrow_keys().inverted()),
+                    ),
+                ])
+            ),
+            SpatialBundle::default(),
+        ))
+        .with_children(|rig| {
+            joint_entity = rig
+                .spawn((CameraJoint, SpatialBundle::default()))
+                .with_children(|joint| {
+                    camera_entity = joint
+                        .spawn((
+                            PrimaryCamera,
+                            Camera3dBundle {
+                                transform: Transform::from_xyz(0.0, 0.0, 10.0),
+                                projection: Projection::Perspective(PerspectiveProjection {
+                                    fov: (50.5_f32).to_radians(),
+                                    ..default()
+                                }),
+                                ..default()
+                            },
+                        ))
+                        .id();
+                })
+                .id();
+        })
+        .insert(CameraRig {
+            camera_entity,
+            joint_entity,
+            target: None,
+        });
+}
+
+#[derive(Actionlike, PartialEq, Eq, Hash, Clone, Copy, Debug, Reflect)]
+pub enum CameraAction {
+    Move,
+    Zoom,
+}
+
+impl CameraAction {
+    pub const ZOOM_SPEED: f32 = 10.0;
+}
+
+pub type CameraActionState = ActionState<CameraAction>;
+
+pub fn control_camera_rig(
+    mut query_rig: Query<(&CameraActionState, &CameraRig, &mut Transform)>,
+    mut query_joint: Query<&mut Transform, (With<CameraJoint>, Without<CameraRig>)>,
+    time: Res<Time>
+) {
+    for (action_state, rig, mut transform) in query_rig.iter_mut() {
+        // translation applied to the root entity
+        if action_state.pressed(&CameraAction::Move) {
+            if let Some(clamped_axis) = action_state.clamped_axis_pair(&CameraAction::Move) {
+                println!("clamped_axis: {:?}", clamped_axis);
+                let translation = Vec3::new(clamped_axis.x(), clamped_axis.y(), 0.0);
+                transform.translation += translation * time.delta_seconds();
+            }
+        }
+
+        // zoom applied to the joint entity
+        if action_state.pressed(&CameraAction::Zoom) {
+            let clamped_value = action_state.clamped_value(&CameraAction::Zoom);
+            if let Ok(mut joint_transform) = query_joint.get_mut(rig.joint_entity) {
+                joint_transform.translation.z +=
+                    clamped_value * CameraAction::ZOOM_SPEED * time.delta_seconds();
+            }
+        }
+    }
+}
+
+pub struct CameraRigPlugin;
+
+impl Plugin for CameraRigPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_type::<CameraAction>()
+            .register_type::<CameraActionState>()
+            .register_type::<CameraRig>()
+            .register_type::<CameraJoint>()
+            .register_type::<PrimaryCamera>();
+
+        app.add_plugins(InputManagerPlugin::<CameraAction>::default())
+            .add_systems(Startup, spawn_camera_rig)
+            .add_systems(Update, control_camera_rig);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,36 @@
+use bevy::{ prelude::*, sprite::MaterialMesh2dBundle };
+
+mod camera_rig;
+
 fn main() {
-    println!("Hello, world!");
+
+    let mut app = App::new();
+
+    // external plugins
+    app.add_plugins(DefaultPlugins).insert_resource(
+        ClearColor(Color::rgba_linear(0.22, 0.402, 0.598, 1.0))
+    );
+
+    // crate plugins
+    app.add_plugins(camera_rig::CameraRigPlugin);
+
+    // main systems
+    app.add_systems(Startup, setup);
+
+    // run
+    app.run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>
+) {
+    // cuboid
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Mesh::from(Cuboid::default())),
+        material: materials.add(StandardMaterial::default()),
+        transform: Transform::from_rotation(Quat::from_rotation_y((15_f32).to_radians())),
+        ..Default::default()
+    });
 }


### PR DESCRIPTION
Added a basic scene, controls, and a hierarchy of entities we can use to orient the camera. Treat it like a rig. Don't touch the camera's translation.