### PR TITLE
Logic commands

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,3 +30,15 @@ impl<'w, 's> SpawnDemoLights for Commands<'w, 's> {
         });
     }
 }
+
+/// Creates a rounded rectangle mesh. The rectangle is centered at the origin.
+pub fn gate_mesh(input_count: usize, output_count: usize) -> Mesh {
+    const GATE_SIZE: f32 = 1.0;
+    const GATE_THICKNESS: f32 = 0.25;
+
+    let gate_height = GATE_SIZE * ((input_count.max(output_count) / 2).max(1) as f32);
+
+    #[allow(deprecated)]
+    let mesh = Mesh::from(shape::Box::new(GATE_SIZE, gate_height, GATE_THICKNESS));
+    mesh
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,32 @@
+use bevy::prelude::*;
+
+pub trait SpawnDemoLights {
+    fn spawn_demo_lights(&mut self);
+}
+
+impl<'w, 's> SpawnDemoLights for Commands<'w, 's> {
+    fn spawn_demo_lights(&mut self) {
+        self.spawn(PointLightBundle {
+            point_light: PointLight {
+                shadows_enabled: true,
+                ..default()
+            },
+            transform: Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        });
+
+        self.spawn(DirectionalLightBundle {
+            directional_light: DirectionalLight {
+                shadows_enabled: true,
+                illuminance: 10_752.7,
+                ..default()
+            },
+            transform: Transform {
+                translation: Vec3::new(0.0, 2.0, 0.0),
+                rotation: Quat::from_rotation_x(-std::f32::consts::FRAC_PI_4),
+                ..default()
+            },
+            ..default()
+        });
+    }
+}

--- a/src/logic/command_extensions.rs
+++ b/src/logic/command_extensions.rs
@@ -1,0 +1,64 @@
+use bevy::prelude::*;
+
+use super::{
+    commands::{ LogicEntityCommands, SpawnSourcesAndSinks },
+    gates::*,
+    components::*,
+    signal::Signal,
+};
+
+/// A trait for spawning a "battery" entity.
+pub trait BatteryExt<'w, 's> {
+    fn battery<T>(&mut self, strength: T) -> LogicEntityCommands where T: Into<Signal>;
+}
+
+impl<'w, 's, 'a> BatteryExt<'w, 's> for Commands<'w, 's> {
+    fn battery<T>(&mut self, strength: T) -> LogicEntityCommands where T: Into<Signal> {
+        let entity_commands = self.spawn(Battery::new(strength.into()));
+        let mut logic_commands = LogicEntityCommands::new(entity_commands);
+        logic_commands.with_sources(1);
+        logic_commands
+    }
+}
+
+/// A trait for spawning a "wire" entity.
+pub trait WireExt<'w, 's> {
+    fn wire(&mut self, source: Entity, sink: Entity) -> &mut Self;
+}
+
+impl<'w, 's, 'a> WireExt<'w, 's> for Commands<'w, 's> {
+    fn wire(&mut self, source: Entity, sink: Entity) -> &mut Self {
+        self.spawn(Wire { source, sink });
+        self
+    }
+}
+
+/// A trait for spawning common logic gates.
+pub trait LogicGateExt<'w, 's> {
+    fn not_gate(&mut self) -> LogicEntityCommands;
+    fn and_gate(&mut self) -> LogicEntityCommands;
+    fn or_gate(&mut self, is_adder: bool) -> LogicEntityCommands;
+}
+
+impl<'w, 's, 'a> LogicGateExt<'w, 's> for Commands<'w, 's> {
+    fn and_gate(&mut self) -> LogicEntityCommands {
+        let entity_commands = self.spawn(AndGate);
+        let mut logic_commands = LogicEntityCommands::new(entity_commands);
+        logic_commands.with_sources(2).with_sinks(1);
+        logic_commands
+    }
+
+    fn not_gate(&mut self) -> LogicEntityCommands {
+        let entity_commands = self.spawn(NotGate);
+        let mut logic_commands = LogicEntityCommands::new(entity_commands);
+        logic_commands.with_sources(1).with_sinks(1);
+        logic_commands
+    }
+
+    fn or_gate(&mut self, is_adder: bool) -> LogicEntityCommands {
+        let entity_commands = self.spawn(OrGate { is_adder });
+        let mut logic_commands = LogicEntityCommands::new(entity_commands);
+        logic_commands.with_sources(2).with_sinks(1);
+        logic_commands
+    }
+}

--- a/src/logic/commands.rs
+++ b/src/logic/commands.rs
@@ -1,0 +1,100 @@
+use bevy::{ ecs::system::EntityCommands, prelude::*, utils::smallvec::SmallVec };
+use derive_new::new;
+
+use super::components::{ Source, Sink };
+
+#[derive(new)]
+pub struct LogicEntityCommands<'a> {
+    entity_commands: EntityCommands<'a>,
+    #[new(default)]
+    sources: SmallVec<[Entity; 4]>,
+    #[new(default)]
+    sinks: SmallVec<[Entity; 4]>,
+}
+
+impl LogicEntityCommands<'_> {
+    /// Insert a bundle of components using the entity commands
+    /// associated with this logic entity.
+    #[inline]
+    pub fn insert(&mut self, bundle: impl Bundle) -> &mut Self {
+        self.entity_commands.insert(bundle);
+        self
+    }
+
+    /// Downgrade this command builder into a logic entity, dropping
+    /// the mutable reference to entity commands.
+    pub fn downgrade(self) -> LogicEntity {
+        LogicEntity {
+            node: self.entity_commands.id(),
+            sources: self.sources,
+            sinks: self.sinks,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct LogicEntity {
+    node: Entity,
+    sources: SmallVec<[Entity; 4]>,
+    sinks: SmallVec<[Entity; 4]>,
+}
+
+/// A trait that allows getting a source or sink [Entity] by index.
+pub trait SourceSinkGetter {
+    /// Returns the source [Entity] at `index`, if it exists.
+    fn source(&self, index: usize) -> Option<Entity>;
+
+    /// Returns the sink [Entity] at `index`, if it exists.
+    fn sink(&self, index: usize) -> Option<Entity>;
+}
+
+impl SourceSinkGetter for LogicEntityCommands<'_> {
+    fn source(&self, index: usize) -> Option<Entity> {
+        self.sources.get(index).copied()
+    }
+
+    fn sink(&self, index: usize) -> Option<Entity> {
+        self.sinks.get(index).copied()
+    }
+}
+
+impl SourceSinkGetter for LogicEntity {
+    fn source(&self, index: usize) -> Option<Entity> {
+        self.sources.get(index).copied()
+    }
+
+    fn sink(&self, index: usize) -> Option<Entity> {
+        self.sinks.get(index).copied()
+    }
+}
+
+/// A trait that allows spawning child entities with [`Source`] and [`Sink`] components.
+pub trait SpawnSourcesAndSinks {
+    /// Spawns `count` child entities with [`Source`] components.
+    fn with_sources(&mut self, count: usize) -> &mut Self;
+
+    /// Spawns `count` child entities with [`Sink`] components.
+    fn with_sinks(&mut self, count: usize) -> &mut Self;
+}
+
+impl SpawnSourcesAndSinks for LogicEntityCommands<'_> {
+    fn with_sources(&mut self, count: usize) -> &mut Self {
+        self.entity_commands.with_children(|entity| {
+            for _ in 0..count {
+                let source = entity.spawn(Source::default()).id();
+                self.sources.push(source);
+            }
+        });
+        self
+    }
+
+    fn with_sinks(&mut self, count: usize) -> &mut Self {
+        self.entity_commands.with_children(|entity| {
+            for _ in 0..count {
+                let sink = entity.spawn(Sink::default()).id();
+                self.sinks.push(sink);
+            }
+        });
+        self
+    }
+}

--- a/src/logic/gates.rs
+++ b/src/logic/gates.rs
@@ -22,8 +22,9 @@ impl Plugin for LogicGatePlugin {
         // If we don't register them, they will be invisible to the game engine.
         use bevy_trait_query::RegisterExt;
 
-        app.register_component_as::<dyn LogicGate, NotGate>()
+        app.register_component_as::<dyn LogicGate, Battery>()
             .register_component_as::<dyn LogicGate, AndGate>()
+            .register_component_as::<dyn LogicGate, NotGate>()
             .register_component_as::<dyn LogicGate, OrGate>();
     }
 }
@@ -68,6 +69,36 @@ impl LogicGate for OrGate {
         };
         outputs.iter_mut().for_each(|output| {
             *output = signal;
+        });
+    }
+}
+
+/// A battery that emits a constant signal.
+#[derive(Component, Clone, Copy, Debug)]
+pub struct Battery {
+    pub signal: Signal,
+}
+
+impl Default for Battery {
+    fn default() -> Self {
+        Self::MAX
+    }
+}
+
+impl Battery {
+    pub const OFF: Battery = Battery::new(Signal::OFF);
+    pub const MAX: Battery = Battery::new(Signal::ON);
+    pub const MIN: Battery = Battery::new(Signal::NEG);
+
+    pub const fn new(signal: Signal) -> Self {
+        Self { signal }
+    }
+}
+
+impl LogicGate for Battery {
+    fn evaluate(&self, _: &[Signal], outputs: &mut [Signal]) {
+        outputs.iter_mut().for_each(|output| {
+            *output = self.signal;
         });
     }
 }

--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -3,23 +3,27 @@ use bevy::prelude::*;
 #[allow(unused_imports)]
 pub mod prelude {
     pub use super::components::*;
-    pub use super::gates::{ NotGate, AndGate, OrGate };
+    pub use super::gates::{ LogicGatePlugin, Battery, NotGate, AndGate, OrGate };
     pub use super::signal::Signal;
+    pub use super::command_extensions::*;
+    pub use super::commands::{ LogicEntity, LogicEntityCommands, SourceSinkGetter };
 }
 
+pub mod commands;
+pub mod command_extensions;
 pub mod signal;
 pub mod gates;
 pub mod components {
     use super::{ *, signal::Signal };
 
     /// An output node.
-    #[derive(Component, Clone, Copy, Debug)]
+    #[derive(Component, Clone, Copy, Debug, Default)]
     pub struct Source {
         pub signal: Signal,
     }
 
     /// An input node.
-    #[derive(Component, Clone, Copy, Debug)]
+    #[derive(Component, Clone, Copy, Debug, Default)]
     pub struct Sink {
         pub signal: Signal,
     }

--- a/src/logic/signal.rs
+++ b/src/logic/signal.rs
@@ -8,9 +8,16 @@ pub enum Signal {
     Undefined,
 }
 
+impl Default for Signal {
+    fn default() -> Self {
+        Signal::Undefined
+    }
+}
+
 impl Signal {
     pub const OFF: Signal = Signal::Digital(false);
     pub const ON: Signal = Signal::Digital(true);
+    pub const NEG: Signal = Signal::Analog(-1.0);
 
     /// Returns true if the signal is true or greater or equal to 1.0.
     pub fn is_true(&self) -> bool {


### PR DESCRIPTION
This adds batteries and traits that extend bevy's `Commands` to make it easier to spawn and link logic entities.