### PR TITLE
Remove debug assertion that will cause errors with disjoint circuits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_logic"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bevy",
  "bevy-inspector-egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_logic"
 description = "A logic gate simulation plugin for Bevy."
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Jacob Bergholtz"]
 homepage = "https://github.com/cuppachino/bevy_logic"
 repository = "https://github.com/cuppachino/bevy_logic"

--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ fn spawn_custom_gate(mut commands: Commands, mut sim: ResMut<LogicGraph>) {
 
 | `bevy` | `bevy_logic` |
 | ------ | ------------ |
-| 0.13   | 0.1.*        |
+| 0.13   | 0.1.1        |

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -67,16 +67,7 @@ impl LogicGraph {
     }
 
     pub fn compile(&mut self) {
-        let post_order = kosaraju_scc(&self.graph);
-
-        // Assert that all vecs contain a single element.
-        #[cfg(debug_assertions)]
-        for component in post_order.iter() {
-            assert_eq!(component.len(), 1);
-        }
-
-        // flatten the vec of vecs into a single vec
-        self.sorted = post_order.into_iter().flatten().rev().collect();
+        self.sorted = kosaraju_scc(&self.graph).into_iter().flatten().rev().collect();
     }
 
     pub fn sorted(&self) -> &[Entity] {


### PR DESCRIPTION
It's fine if there are multiple components evaluated in the same step because they will belong to separate circuits.