### PR TITLE
Refactor "truthy" and "falsy" Analog Signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_logic"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bevy",
  "bevy-inspector-egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_logic"
 description = "A logic gate simulation plugin for Bevy."
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Jacob Bergholtz"]
 homepage = "https://github.com/cuppachino/bevy_logic"
 repository = "https://github.com/cuppachino/bevy_logic"

--- a/README.md
+++ b/README.md
@@ -65,10 +65,7 @@ struct CustomLogicPlugin;
 
 impl Plugin for CustomLogicPlugin {
     fn build(&self, app: &mut App) {
-        // We must import this trait in order to register our components.
-        // If we don't register them, they will be invisible to the game engine.
-        use bevy_trait_query::RegisterExt;
-        app.register_component_as::<dyn LogicGate, XorGate>()
+        app.register_logic_gate::<XorGate>();
     }
 }
 ```

--- a/examples/advanced_gates/main.rs
+++ b/examples/advanced_gates/main.rs
@@ -75,8 +75,7 @@ fn main() {
     let mut app = App::new();
 
     // Register the `Selector` as a `LogicGate`.
-    use bevy_trait_query::RegisterExt;
-    app.register_component_as::<dyn LogicGate, Selector>();
+    app.register_logic_gate::<Selector>();
 
     // Add the `LogicSimulationPlugin`.
     app.add_plugins((

--- a/src/logic/gates.rs
+++ b/src/logic/gates.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 use crate::{ logic::{ signal::Signal, LogicGate }, utils::NumExt };
 
-use super::signal::SignalExt;
+use super::{ signal::SignalExt, AppLogicGateExt };
 
 /// This plugin registers basic logic gates and a battery component.
 ///
@@ -20,14 +20,11 @@ pub struct LogicGatePlugin;
 
 impl Plugin for LogicGatePlugin {
     fn build(&self, app: &mut App) {
-        // We must import this trait in order to register our components.
-        // If we don't register them, they will be invisible to the game engine.
-        use bevy_trait_query::RegisterExt;
-        app.register_component_as::<dyn LogicGate, AndGate>()
-            .register_component_as::<dyn LogicGate, OrGate>()
-            .register_component_as::<dyn LogicGate, NotGate>()
-            .register_component_as::<dyn LogicGate, XorGate>()
-            .register_component_as::<dyn LogicGate, Battery>();
+        app.register_logic_gate::<AndGate>()
+            .register_logic_gate::<OrGate>()
+            .register_logic_gate::<NotGate>()
+            .register_logic_gate::<XorGate>()
+            .register_logic_gate::<Battery>();
 
         // Register the components' reflection data.
         app.register_type::<AndGate>()

--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -8,9 +8,10 @@ pub mod prelude {
     pub use super::gates::*;
     pub use super::schedule::prelude::*;
     pub use super::signal::{ Signal, SignalExt };
-    pub use super::LogicGate;
+    pub use super::{ LogicGate, AppLogicGateExt };
 }
 
+use bevy::prelude::*;
 use signal::Signal;
 
 /// A trait that defines the behavior of a logic gate.
@@ -18,4 +19,25 @@ use signal::Signal;
 pub trait LogicGate {
     /// Evaluate the current state of inputs (in order), and update the outputs (in order).
     fn evaluate(&mut self, inputs: &[Signal], outputs: &mut [Signal]);
+}
+
+/// An [App] extension for registering `LogicGate` components through `bevy_trait_query`.
+pub trait AppLogicGateExt {
+    /// Register a component that implements `LogicGate` via `bevy_trait_query`.
+    ///
+    /// Gates must be registered or they will not be queryable.
+    ///
+    /// Calling this multiple times with the same arguments will do nothing on subsequent calls.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called after starting the [`World`] simulation.
+    fn register_logic_gate<T: Component + LogicGate>(&mut self) -> &mut Self;
+}
+
+impl AppLogicGateExt for App {
+    fn register_logic_gate<T: Component + LogicGate>(&mut self) -> &mut Self {
+        use bevy_trait_query::RegisterExt;
+        self.register_component_as::<dyn LogicGate, T>()
+    }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -23,7 +23,7 @@ pub fn step_logic(
         // Get the GATE.
         let (fans, mut gate) = logic_entities
             .get_mut(entity)
-            .expect("Entity does not exist or does not have a LogicFans/LogicGate");
+            .expect("Entity does not exist or does not have a LogicGateFans or dyn LogicGate");
 
         // Collect its fan input signals.
         let input_signals = fans.inputs


### PR DESCRIPTION
I think any non-zero, non-subnormal, non-nan, finite `Signal::Analog` should be allowed to propagate its signal value.

This is useful for arithmetic gates and doesn't affect `Digital` signals.

Also included a QoL component-registering trait for `App`.