### PR TITLE
Solution for output signals that do not require evaluation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_logic"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "bevy",
  "bevy-inspector-egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_logic"
 description = "A logic gate simulation plugin for Bevy."
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Jacob Bergholtz"]
 homepage = "https://github.com/cuppachino/bevy_logic"
 repository = "https://github.com/cuppachino/bevy_logic"

--- a/examples/advanced_gates/main.rs
+++ b/examples/advanced_gates/main.rs
@@ -1,6 +1,6 @@
 use bevy::{ ecs::system::EntityCommands, prelude::* };
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
-use bevy_logic::{ components::GateFan, logic::builder::GateFanEntityMut, prelude::* };
+use bevy_logic::{ logic::builder::{ GateData, GateFanEntityMut, Known }, prelude::* };
 use itertools::Itertools;
 
 mod camera_rig;
@@ -10,72 +10,194 @@ use visual::*;
 
 use crate::camera_rig::CameraRigPlugin;
 
-/// A selector should always have EXACTLY 1 more input
-/// than the number of outputs. The first input is expected
-/// to be the cycle input, instead of the last input because
-/// the number of states/fans may change.
-#[derive(Component, Default)]
-struct Selector {
-    last_input: Option<usize>,
-}
+mod custom_gates {
+    use derive_new::new;
 
-impl LogicGate for Selector {
-    fn evaluate(&mut self, inputs: &[Signal], outputs: &mut [Signal]) {
-        #[cfg(debug_assertions)]
-        {
-            if inputs.len() != outputs.len() + 1 {
-                panic!(
-                    "Selector does not have the correct number of child fans. There must be exactly 1 more input than outputs."
-                );
-            }
-        }
+    use super::*;
 
-        if let Some((index, signal)) = inputs.iter().find_position(|input| { input.is_truthy() }) {
-            if self.last_input.is_some_and(|i| i == index) {
-                return;
-            } else {
-                self.last_input.replace(index);
-            }
+    /// A selector acts like a state machine. It has an even number of standard inputs and outputs, and 1 "cycle" input.
+    ///
+    /// Selectors should *always* have *exactly* 1 more input
+    /// than outputs.
+    ///
+    /// Higher inputs take priority over lower ones.
+    ///
+    /// The cycle input is ignored if it was previously evaluated and the signal is still truthy.
+    #[derive(Component, Clone, Debug, Default, Reflect)]
+    pub struct Selector {
+        stale_cycle_input: bool,
+    }
 
-            if index == 0 {
-                let mut iter = outputs.iter_mut().skip_while(|o| o.is_falsy());
-                if let Some(active) = iter.next() {
-                    active.turn_off();
+    impl LogicGate for Selector {
+        fn evaluate(&mut self, inputs: &[Signal], outputs: &mut [Signal]) {
+            #[cfg(debug_assertions)]
+            {
+                if inputs.len() != outputs.len() + 1 {
+                    panic!(
+                        "Selector does not have the correct number of child fans. There must be exactly 1 more input than outputs."
+                    );
                 }
-                if let Some(next) = iter.next() {
-                    next.replace(*signal);
+            }
+
+            if
+                let Some((index, signal)) = inputs
+                    .iter()
+                    .rev()
+                    .find_position(|input| { input.is_truthy() })
+            {
+                // flip the index
+                let index = inputs.len() - 1 - index;
+
+                if index == 0 {
+                    if self.stale_cycle_input {
+                        return;
+                    } else {
+                        self.stale_cycle_input = true;
+                    }
+
+                    let mut iter = outputs.iter_mut().skip_while(|o| o.is_falsy());
+                    if let Some(active) = iter.next() {
+                        active.turn_off();
+                    }
+                    if let Some(next) = iter.next() {
+                        next.replace(*signal);
+                    } else {
+                        outputs
+                            .first_mut()
+                            .expect("Selector does not have any outputs")
+                            .replace(*signal);
+                    }
                 } else {
+                    // self.last_input.replace(index);
+                    outputs.set_all(Signal::OFF);
                     outputs
-                        .first_mut()
-                        .expect("Selector does not have any outputs")
+                        .get_mut(index - 1)
+                        .unwrap()
                         .replace(*signal);
                 }
+                return;
             } else {
-                self.last_input.replace(index);
-                outputs.set_all(Signal::OFF);
-                outputs
-                    .get_mut(index - 1)
-                    .unwrap()
-                    .replace(*signal);
+                self.stale_cycle_input = false;
             }
-            return;
-        } else {
-            self.last_input = None;
+
+            if outputs.iter().all(|s| s.is_falsy()) {
+                if let Some(first) = outputs.first_mut() {
+                    first.turn_on();
+                }
+            }
+        }
+    }
+    /// A counter counts input signal pulses up to the target value, and
+    /// only emits a signal once the target is met, unless the `signal_strength` is true,
+    /// in which case the output signal is a value between `0.0..1.0` representing the
+    /// completion of the counter.
+    ///
+    /// Counters have 1 standard input, 1 reset input, and 1 output.
+    ///
+    /// The first input is used as the "reset" input.
+    #[derive(new, Component, Clone, Debug, Reflect)]
+    pub struct Counter {
+        /// The current count.
+        pub current: i8,
+        /// The max/target count.
+        pub target: i8,
+        /// If true, output a value between `0.0..1.0` representing the completion state of the counter.
+        pub signal_strength: bool,
+        /// Stores the previously evaluated inputs so that solid signals do not continuously trigger their input.
+        #[new(default)]
+        #[reflect(ignore)]
+        stale_inputs: [bool; 2],
+    }
+
+    impl Default for Counter {
+        fn default() -> Self {
+            Self {
+                current: 0,
+                target: 10,
+                signal_strength: false,
+                stale_inputs: [false; 2],
+            }
+        }
+    }
+
+    impl Counter {
+        /// Increments the counter if [`Self::current`] is less than [`Self::target`].
+        #[inline]
+        pub fn increment(&mut self) {
+            if self.current < self.target {
+                self.current += 1;
+            }
         }
 
-        if outputs.iter().all(|s| s.is_falsy()) {
-            if let Some(first) = outputs.first_mut() {
-                first.turn_on();
+        /// Decrement the counter if [`Self::curent`] is greater than `0`.
+        #[inline]
+        pub fn decrement(&mut self) {
+            if self.current > 0 {
+                self.current -= 1;
+            }
+        }
+
+        /// Reset the counter to `0`.
+        #[inline]
+        pub fn reset(&mut self) {
+            self.current = 0;
+        }
+
+        /// Returns `Self::current / Self::target` as a [`Signal`].
+        pub fn signal_strength(&self) -> Signal {
+            ((self.current as f32) / (self.target as f32)).into()
+        }
+
+        /// Returns a [`Signal::Digital`] that is true if [`Self::current`] is equal to [`Self::target`]
+        pub fn signal_on_off(&self) -> Signal {
+            (self.current == self.target).into()
+        }
+    }
+
+    impl LogicGate for Counter {
+        fn evaluate(&mut self, inputs: &[Signal], outputs: &mut [Signal]) {
+            if let Some((index, signal)) = inputs.iter().find_position(|s| s.is_truthy()) {
+                if self.stale_inputs[index] {
+                    return;
+                } else {
+                    self.stale_inputs[index] = true;
+                }
+
+                match index {
+                    0 => self.reset(),
+                    1 => {
+                        if signal.is_sign_negative() {
+                            self.decrement();
+                        } else {
+                            self.increment();
+                        }
+                    }
+                    _ => panic!("Counter has too many inputs!"),
+                }
+            } else {
+                self.stale_inputs.iter_mut().for_each(|b| {
+                    *b = false;
+                });
+            }
+
+            let output = outputs.get_mut(0).expect("Counter should have one output!");
+            if self.signal_strength {
+                output.replace(self.signal_strength());
+            } else {
+                let signal = self.signal_on_off();
+                output.replace(signal);
             }
         }
     }
 }
 
 fn main() {
+    const TICKS_PER_SECOND: f64 = 30.0;
+
     let mut app = App::new();
 
-    // Register the `Selector` as a `LogicGate`.
-    app.register_logic_gate::<Selector>();
+    // Register the [`Selector`] as a `LogicGate`.
+    app.register_logic_gate::<custom_gates::Selector>().register_logic_gate::<custom_gates::Counter>();
 
     // Add the `LogicSimulationPlugin`.
     app.add_plugins((
@@ -85,119 +207,383 @@ fn main() {
         LogicSimulationPlugin,
     ))
         .insert_resource(ClearColor(Color::rgba_linear(0.22, 0.402, 0.598, 1.0)))
-        .add_systems(Startup, (setup_scene, spawn_logic))
+        // .insert_resource(Time::<LogicStep>::from_seconds(1.0 / (TICKS_PER_SECOND as f64)))
+        .insert_resource(Time::<LogicStep>::from_hz(TICKS_PER_SECOND))
+        .add_systems(Startup, systems::setup_scene)
         .add_systems(Update, gizmo_wires)
+        .add_systems(
+            Update,
+            systems::reserve_ui_button_signal.before(LogicSystemSet::PropagateNoEval)
+        )
+        .add_systems(
+            LogicUpdate,
+            systems::release_ui_button_signals.after(LogicSystemSet::StepLogic)
+        )
         .run();
 }
 
-fn setup_scene(mut commands: Commands) {
-    commands.spawn(PointLightBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, 0.0, 5.0)),
-        point_light: PointLight {
-            intensity: 150000.0,
+mod systems {
+    use super::*;
+
+    /// Scene setup.
+    pub fn setup_scene(
+        mut commands: Commands,
+        mut sim: ResMut<LogicGraph>,
+        mut meshes: ResMut<Assets<Mesh>>,
+        mut materials: ResMut<Assets<StandardMaterial>>
+    ) {
+        // Spawn a light
+        commands.spawn(PointLightBundle {
+            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 5.0)),
+            point_light: PointLight {
+                intensity: 150000.0,
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    });
-}
+        });
 
-fn spawn_logic(
-    mut commands: Commands,
-    mut sim: ResMut<LogicGraph>,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>
-) {
-    let selector = commands
-        .spawn_gate((
-            Name::new("Selector"),
-            Selector::default(),
-            pbr(Vec3::new(-1.0, 0.0, 0.0), meshes.add(build_mesh(4, 4, 1)), &mut materials),
-        ))
-        .build_inputs(5, selector_input_entity_mut(5))
-        .build_outputs(4, fan_entity_mut(GateFan::Output, 4))
-        .build();
+        // Create a selector with 5 states (and one cycle input).
+        let selector = helpers::spawn_selector(
+            &mut commands,
+            &mut meshes,
+            &mut materials,
+            5,
+            Vec2::new(-1.0, 0.0)
+        );
 
-    let or_gate = commands
-        .spawn_gate((
-            Name::new("OR"),
-            OrGate::default(),
-            pbr(Vec3::new(2.0, 1.0, 0.0), meshes.add(build_mesh(3, 1, 0)), &mut materials),
-        ))
-        .build_inputs(3, fan_entity_mut(GateFan::Input, 3))
-        .build_outputs(1, fan_entity_mut(GateFan::Output, 1))
-        .build();
+        // Prepare 4 AND gates with 2 inputs each.
+        let and_a = helpers::spawn_and_gate(
+            &mut commands,
+            &mut meshes,
+            &mut materials,
+            2,
+            Vec2::new(3.0, 3.0)
+        );
+        let and_b = helpers::spawn_and_gate(
+            &mut commands,
+            &mut meshes,
+            &mut materials,
+            2,
+            Vec2::new(3.0, 1.0)
+        );
+        let and_c = helpers::spawn_and_gate(
+            &mut commands,
+            &mut meshes,
+            &mut materials,
+            2,
+            Vec2::new(3.0, -1.0)
+        );
+        let and_d = helpers::spawn_and_gate(
+            &mut commands,
+            &mut meshes,
+            &mut materials,
+            2,
+            Vec2::new(3.0, -3.0)
+        );
 
-    sim.add_data(
-        vec![
-            commands.spawn_wire(&selector, 0, &or_gate, 0).downgrade(),
-            commands.spawn_wire(&selector, 1, &or_gate, 1).downgrade(),
-            commands.spawn_wire(&selector, 3, &or_gate, 2).downgrade()
-        ]
-    )
-        .add_data(selector)
-        .add_data(or_gate)
-        .compile();
-}
+        // Spawn the keypad.
+        let keypad = helpers::spawn_keypad_ui(&mut commands);
 
-pub const GATE_UNIT_SIZE: f32 = 1.0;
-pub const GATE_UNIT_HALF_SIZE: f32 = 0.5;
-pub const GATE_UNIT_HALF_THICKNESS: f32 = 0.05;
+        // Spawn "one-shot" counters - counters that count to 1 and then reset.
+        let counter_a = helpers::spawn_counter(
+            &mut commands,
+            &mut meshes,
+            &mut materials,
+            1,
+            false,
+            Vec2::new(1.0, 2.0)
+        );
+        sim.add_data(commands.spawn_wire(&counter_a, 0, &counter_a, 0).downgrade());
 
-fn selector_input_entity_mut(total_inputs: usize) -> impl GateFanEntityMut {
-    let normal_inputs = total_inputs - 1;
-    let height = ((normal_inputs as f32) * 0.5 * GATE_UNIT_SIZE).max(GATE_UNIT_SIZE);
-    let half_height = height * 0.5;
-    let section_height: f32 = height / (total_inputs as f32);
+        let counter_bc = helpers::spawn_counter(
+            &mut commands,
+            &mut meshes,
+            &mut materials,
+            1,
+            false,
+            Vec2::new(1.0, 0.0)
+        );
+        sim.add_data(commands.spawn_wire(&counter_bc, 0, &counter_bc, 0).downgrade());
 
-    move |cmd: &mut EntityCommands, index: usize| {
-        if index == 0 {
-            let position = Vec3::new(0.0, -half_height, 0.0);
-            cmd.insert((
-                Name::new("in.cycle"),
-                SpatialBundle::from_transform(Transform::from_translation(position)),
-            ));
-        } else {
-            let position = Vec3::new(
-                -GATE_UNIT_HALF_SIZE,
-                -1.0 * (section_height * (index as f32) - half_height),
-                0.0
-            );
-            cmd.insert((
-                Name::new(format!("in.{index}")),
-                SpatialBundle::from_transform(Transform::from_translation(position)),
-            ));
+        let counter_d = helpers::spawn_counter(
+            &mut commands,
+            &mut meshes,
+            &mut materials,
+            1,
+            false,
+            Vec2::new(1.0, -2.0)
+        );
+        sim.add_data(commands.spawn_wire(&counter_d, 0, &counter_d, 0).downgrade());
+
+        // Our UI button's don't take any inputs, do not need evaluation, and
+        // do not need to be sorted by the [`LogicGraph`]. We'll wire each keypad
+        // to a "one-shot" counter and then wire the counters to the appropriate AND gate.
+        commands.spawn_no_eval_wire(keypad[1], counter_a.input(1)); // 2 -> counter std.in 0
+        commands.spawn_no_eval_wire(keypad[0], counter_bc.input(1)); // 1 -> counter std.in 0
+        commands.spawn_no_eval_wire(keypad[7], counter_d.input(1)); // 8 -> counter std.in 0
+
+        // We still add logic gates because they always need to be evaluated.
+        sim.add_data(
+            vec![
+                // Wire each selector output to an AND gate.
+                commands.spawn_wire(&selector, 0, &and_a, 0).downgrade(), // 0 -> and 0
+                commands.spawn_wire(&selector, 1, &and_b, 0).downgrade(), // 1 -> and 0
+                commands.spawn_wire(&selector, 2, &and_c, 0).downgrade(), // 2 -> and 0
+                commands.spawn_wire(&selector, 3, &and_d, 0).downgrade(), // 3 -> and 0
+
+                // Wire each counter output to an AND gate.
+                commands.spawn_wire(&counter_a, 0, &and_a, 1).downgrade(), // std.in 0 -> and 0
+                commands.spawn_wire(&counter_bc, 0, &and_b, 1).downgrade(), // std.in 0 -> and 0
+                commands.spawn_wire(&counter_bc, 0, &and_c, 1).downgrade(), // std.in 0 -> and 0
+                commands.spawn_wire(&counter_d, 0, &and_d, 1).downgrade(), // std.in 0 -> and 0
+
+                // Wire each and gate to the next selector INPUT except for the last one.
+                commands.spawn_wire(&and_a, 0, &selector, 2).downgrade(), // and a -> selector std.in 1
+                commands.spawn_wire(&and_b, 0, &selector, 3).downgrade(), // and b -> selector std.in 2
+                commands.spawn_wire(&and_c, 0, &selector, 4).downgrade(), // and c -> selector std.in 3
+                commands.spawn_wire(&and_d, 0, &selector, 5).downgrade() // and d -> selector std.in 4
+            ]
+        )
+            .add_data(vec![selector, and_a, and_b, and_c, and_d, counter_a, counter_bc, counter_d])
+            .compile();
+    }
+
+    /// This system allows players to activate a button immediately and leave the button
+    /// on until the logic step system has ran.
+    ///
+    /// Hover/None effects are applied as long as the button hasn't been pressed yet.
+    pub fn reserve_ui_button_signal(
+        mut query_buttons: Query<
+            (&Interaction, &mut BackgroundColor, &mut Signal),
+            (Changed<Interaction>, With<Button>)
+        >
+    ) {
+        for (interaction, mut color, mut signal) in &mut query_buttons {
+            match *interaction {
+                Interaction::Pressed => {
+                    *color = Color::GREEN.into();
+                    *signal = Signal::ON;
+                }
+                Interaction::Hovered => {
+                    if signal.is_falsy() {
+                        *color = Color::DARK_GRAY.into();
+                    }
+                }
+                Interaction::None => {
+                    if signal.is_falsy() {
+                        *color = Color::GRAY.into();
+                    }
+                }
+            }
+        }
+    }
+
+    /// Runs after the logic step function and updates the state of the button to match.
+    pub fn release_ui_button_signals(
+        mut query_buttons: Query<
+            (&Interaction, &mut BackgroundColor, &mut Signal),
+            (Changed<Interaction>, With<Button>)
+        >
+    ) {
+        for (interaction, mut color, mut signal) in &mut query_buttons {
+            match *interaction {
+                Interaction::Pressed => {
+                    *color = Color::GREEN.into();
+                    *signal = Signal::ON;
+                }
+                Interaction::Hovered => {
+                    *color = Color::DARK_GRAY.into();
+                    *signal = Signal::OFF;
+                }
+                Interaction::None => {
+                    *color = Color::GRAY.into();
+                    *signal = Signal::OFF;
+                }
+            }
         }
     }
 }
 
-fn fan_entity_mut(kind: GateFan, num_ports: usize) -> impl GateFanEntityMut {
-    let height = ((num_ports as f32) * 0.5 * GATE_UNIT_SIZE).max(GATE_UNIT_SIZE);
-    let half_height = height * 0.5;
-    let section_height: f32 = height / ((num_ports + 1) as f32);
+mod helpers {
+    use super::*;
 
-    let x = match kind {
-        GateFan::Input => -GATE_UNIT_HALF_SIZE,
-        GateFan::Output => GATE_UNIT_HALF_SIZE,
-    };
-    move |cmd: &mut EntityCommands, index: usize| {
-        let position = Vec3::new(
-            x,
-            -1.0 * (section_height * ((1 + index) as f32) - half_height),
-            0.0
-        );
-        cmd.insert(SpatialBundle::from_transform(Transform::from_translation(position)));
+    /// Spawns 9 UI buttons in the shape of a keypad and returns their entity IDs.
+    ///
+    /// The buttons have an [`OutputBundle`] and [`NoEvalOutput`] component that lets
+    /// them act as standalone outputs and forward their signal without "evaluating".
+    pub fn spawn_keypad_ui(commands: &mut Commands) -> [Entity; 9] {
+        let mut entities = [Entity::PLACEHOLDER; 9];
+        commands
+            .spawn(NodeBundle {
+                style: Style {
+                    display: Display::Grid,
+                    grid_template_columns: vec![RepeatedGridTrack::auto(3)],
+                    grid_template_rows: vec![RepeatedGridTrack::auto(3)],
+                    aspect_ratio: Some(1.0),
+                    height: Val::Percent(10.0),
+                    row_gap: Val::Px(8.0),
+                    column_gap: Val::Px(8.0),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .with_children(|root| {
+                for (i, entity) in entities.iter_mut().enumerate() {
+                    *entity = root
+                        .spawn((
+                            OutputBundle::default(),
+                            NoEvalOutput,
+                            ButtonBundle {
+                                background_color: Color::GRAY.into(),
+                                style: Style {
+                                    aspect_ratio: Some(1.0),
+                                    height: Val::Percent(100.0),
+                                    display: Display::Grid,
+                                    align_items: AlignItems::Center,
+                                    align_content: AlignContent::Center,
+                                    justify_content: JustifyContent::Center,
+                                    justify_items: JustifyItems::Center,
+                                    ..Default::default()
+                                },
+                                ..Default::default()
+                            },
+                        ))
+                        .with_children(|button| {
+                            button.spawn(
+                                TextBundle::from_section(format!("{}", i + 1), TextStyle {
+                                    font_size: 32.0,
+                                    ..default()
+                                })
+                            );
+                        })
+                        .id();
+                }
+            });
+
+        entities
     }
-}
 
-fn pbr(
-    position: Vec3,
-    mesh_handle: Handle<Mesh>,
-    materials: &mut ResMut<Assets<StandardMaterial>>
-) -> impl Bundle {
-    PbrBundle {
-        mesh: mesh_handle,
-        material: materials.add(StandardMaterial::default()),
-        transform: Transform::from_translation(position),
-        ..Default::default()
+    /// Spawns a 3D Selector.
+    pub fn spawn_selector(
+        commands: &mut Commands,
+        meshes: &mut ResMut<Assets<Mesh>>,
+        materials: &mut ResMut<Assets<StandardMaterial>>,
+        states: usize,
+        position: Vec2
+    ) -> GateData<Known, Known> {
+        commands
+            .spawn_gate((
+                Name::new("Selector"),
+                custom_gates::Selector::default(),
+                pbr(position.extend(0.0), meshes.add(build_mesh(states, states, 1)), materials),
+            ))
+            .build_inputs(states + 1, selector_input_entity_mut(states + 1))
+            .build_outputs(states, fan_entity_mut(GateFan::Output, states))
+            .build()
+    }
+
+    /// Spawns a 3D Counter.
+    pub fn spawn_counter(
+        commands: &mut Commands,
+        meshes: &mut ResMut<Assets<Mesh>>,
+        materials: &mut ResMut<Assets<StandardMaterial>>,
+        max_count: i8,
+        signal_strength: bool,
+        position: Vec2
+    ) -> GateData<Known, Known> {
+        commands
+            .spawn_gate((
+                Name::new("Counter"),
+                custom_gates::Counter::new(0, max_count, signal_strength),
+                pbr(position.extend(0.0), meshes.add(build_mesh(1, 1, 1)), materials),
+            ))
+            .build_inputs(2, selector_input_entity_mut(2))
+            .build_outputs(1, fan_entity_mut(GateFan::Output, 1))
+            .build()
+    }
+
+    /// Spawns a 3D AND gate.
+    pub fn spawn_and_gate(
+        commands: &mut Commands,
+        meshes: &mut ResMut<Assets<Mesh>>,
+        materials: &mut ResMut<Assets<StandardMaterial>>,
+        inputs: usize,
+        position: Vec2
+    ) -> GateData<Known, Known> {
+        commands
+            .spawn_gate((
+                Name::new("AND"),
+                AndGate,
+                pbr(position.extend(0.0), meshes.add(build_mesh(inputs, 1, 0)), materials),
+            ))
+            .build_inputs(inputs, fan_entity_mut(GateFan::Input, inputs))
+            .build_outputs(1, fan_entity_mut(GateFan::Output, 1))
+            .build()
+    }
+
+    pub const GATE_UNIT_SIZE: f32 = 1.0;
+    pub const GATE_UNIT_HALF_SIZE: f32 = 0.5;
+    pub const GATE_UNIT_HALF_THICKNESS: f32 = 0.05;
+
+    /// Position the input fans of a [`Selector`] logic gate.
+    pub fn selector_input_entity_mut(total_inputs: usize) -> impl GateFanEntityMut {
+        let normal_inputs = total_inputs - 1;
+        let height = ((normal_inputs as f32) * 0.5 * GATE_UNIT_SIZE).max(GATE_UNIT_SIZE);
+        let half_height = height * 0.5;
+        let section_height: f32 = height / (total_inputs as f32);
+
+        move |cmd: &mut EntityCommands, index: usize| {
+            if index == 0 {
+                let position = Vec3::new(0.0, -half_height, 0.0);
+                cmd.insert((
+                    Name::new("in.cycle"),
+                    SpatialBundle::from_transform(Transform::from_translation(position)),
+                ));
+            } else {
+                let position = Vec3::new(
+                    -GATE_UNIT_HALF_SIZE,
+                    -1.0 * (section_height * (index as f32) - half_height),
+                    0.0
+                );
+                cmd.insert((
+                    Name::new(format!("in.{index}")),
+                    SpatialBundle::from_transform(Transform::from_translation(position)),
+                ));
+            }
+        }
+    }
+
+    /// Position the fans of a generic logic gate.
+    pub fn fan_entity_mut(kind: GateFan, num_ports: usize) -> impl GateFanEntityMut {
+        let height = ((num_ports as f32) * 0.5 * GATE_UNIT_SIZE).max(GATE_UNIT_SIZE);
+        let half_height = height * 0.5;
+        let section_height: f32 = height / ((num_ports + 1) as f32);
+
+        let x = match kind {
+            GateFan::Input => -GATE_UNIT_HALF_SIZE,
+            GateFan::Output => GATE_UNIT_HALF_SIZE,
+        };
+        move |cmd: &mut EntityCommands, index: usize| {
+            let position = Vec3::new(
+                x,
+                -1.0 * (section_height * ((1 + index) as f32) - half_height),
+                0.0
+            );
+            cmd.insert(SpatialBundle::from_transform(Transform::from_translation(position)));
+        }
+    }
+
+    /// Create a standard pbr bundle from a position and mesh_handle.
+    pub fn pbr(
+        position: Vec3,
+        mesh_handle: Handle<Mesh>,
+        materials: &mut ResMut<Assets<StandardMaterial>>
+    ) -> impl Bundle {
+        PbrBundle {
+            mesh: mesh_handle,
+            material: materials.add(StandardMaterial::default()),
+            transform: Transform::from_translation(position),
+            ..Default::default()
+        }
     }
 }

--- a/examples/advanced_gates/main.rs
+++ b/examples/advanced_gates/main.rs
@@ -251,7 +251,7 @@ mod systems {
             ..Default::default()
         });
 
-        // Create a selector with 5 states (and one cycle input).
+        // Create a Selector with 5 states (and one cycle input).
         let selector = helpers::spawn_selector(
             &mut commands,
             &mut meshes,
@@ -290,10 +290,7 @@ mod systems {
             Vec2::new(3.0, -3.0)
         );
 
-        // Spawn the keypad.
-        let keypad = helpers::spawn_keypad_ui(&mut commands);
-
-        // Spawn "one-shot" counters - counters that count to 1 and then reset.
+        // Spawn "one-shot" Counters - Counters that count to 1 and then reset.
         let counter_a = helpers::spawn_counter(
             &mut commands,
             &mut meshes,
@@ -323,6 +320,42 @@ mod systems {
             Vec2::new(1.0, -2.0)
         );
         sim.add_data(commands.spawn_wire(&counter_d, 0, &counter_d, 0).downgrade());
+
+        // Spawn the keypad.
+        let keypad = helpers::spawn_keypad_ui(&mut commands);
+
+        // Spawn a "reset" button wired to the first state of the Selector.
+        let reset_button = commands
+            .spawn((
+                camera_rig::UiWorldPosition::default(),
+                OutputBundle::default(),
+                NoEvalOutput,
+                ButtonBundle {
+                    background_color: Color::GRAY.into(),
+                    style: Style {
+                        position_type: PositionType::Absolute,
+                        left: Val::Px(20.0),
+                        bottom: Val::Px(20.0),
+                        padding: UiRect::axes(Val::Px(24.0), Val::Px(8.0)),
+                        align_items: AlignItems::Center,
+                        align_content: AlignContent::Center,
+                        justify_content: JustifyContent::Center,
+                        justify_items: JustifyItems::Center,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            ))
+            .with_children(|button| {
+                button.spawn(
+                    TextBundle::from_section("RESET", TextStyle {
+                        font_size: 32.0,
+                        ..default()
+                    })
+                );
+            })
+            .id();
+        commands.spawn_no_eval_wire(reset_button, selector.input(1)); // button out.0 -> selector std.in 0
 
         // Our UI button's don't take any inputs, do not need evaluation, and
         // do not need to be sorted by the [`LogicGraph`]. We'll wire each keypad
@@ -440,6 +473,7 @@ mod helpers {
                 for (i, entity) in entities.iter_mut().enumerate() {
                     *entity = root
                         .spawn((
+                            camera_rig::UiWorldPosition::default(),
                             OutputBundle::default(),
                             NoEvalOutput,
                             ButtonBundle {

--- a/examples/advanced_gates/main.rs
+++ b/examples/advanced_gates/main.rs
@@ -1,3 +1,13 @@
+//! This example showcases how one might design "advanced" gates with
+//! functionality beyond what is typically permitted in real life.
+//!
+//! In this example, we design a `Selector` and a `Counter`, and spawn a demo circuit
+//! that works as a permutational keypad. For simplicity, we will ignore incorrect key presses and only
+//! require that the correct keys are pressed in order; however, reset functionality could easily
+//! be implemented with a handful of OR gates.
+//!
+//! The valid code will be `2, 1, 1, 8`, in order.
+
 use bevy::{ ecs::system::EntityCommands, prelude::* };
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_logic::{ logic::builder::{ GateData, GateFanEntityMut, Known }, prelude::* };
@@ -207,7 +217,6 @@ fn main() {
         LogicSimulationPlugin,
     ))
         .insert_resource(ClearColor(Color::rgba_linear(0.22, 0.402, 0.598, 1.0)))
-        // .insert_resource(Time::<LogicStep>::from_seconds(1.0 / (TICKS_PER_SECOND as f64)))
         .insert_resource(Time::<LogicStep>::from_hz(TICKS_PER_SECOND))
         .add_systems(Startup, systems::setup_scene)
         .add_systems(Update, gizmo_wires)
@@ -332,10 +341,10 @@ mod systems {
                 commands.spawn_wire(&selector, 3, &and_d, 0).downgrade(), // 3 -> and 0
 
                 // Wire each counter output to an AND gate.
-                commands.spawn_wire(&counter_a, 0, &and_a, 1).downgrade(), // std.in 0 -> and 0
-                commands.spawn_wire(&counter_bc, 0, &and_b, 1).downgrade(), // std.in 0 -> and 0
-                commands.spawn_wire(&counter_bc, 0, &and_c, 1).downgrade(), // std.in 0 -> and 0
-                commands.spawn_wire(&counter_d, 0, &and_d, 1).downgrade(), // std.in 0 -> and 0
+                commands.spawn_wire(&counter_a, 0, &and_a, 1).downgrade(), // out 0 -> and 0
+                commands.spawn_wire(&counter_bc, 0, &and_b, 1).downgrade(), // out 0 -> and 0
+                commands.spawn_wire(&counter_bc, 0, &and_c, 1).downgrade(), // out 0 -> and 0
+                commands.spawn_wire(&counter_d, 0, &and_d, 1).downgrade(), // out 0 -> and 0
 
                 // Wire each and gate to the next selector INPUT except for the last one.
                 commands.spawn_wire(&and_a, 0, &selector, 2).downgrade(), // and a -> selector std.in 1

--- a/examples/advanced_gates/visual.rs
+++ b/examples/advanced_gates/visual.rs
@@ -1,7 +1,7 @@
 use bevy::{ prelude::*, render::{ mesh::PrimitiveTopology, render_asset::RenderAssetUsages } };
-use bevy_logic::{ components::{ GateFan, Wire }, prelude::* };
+use bevy_logic::prelude::*;
 
-use crate::{ triangulation::*, GATE_UNIT_HALF_THICKNESS, GATE_UNIT_SIZE };
+use crate::{ helpers::*, triangulation::* };
 
 pub fn gizmo_wires(
     mut gizmos: Gizmos,

--- a/examples/advanced_gates/visual.rs
+++ b/examples/advanced_gates/visual.rs
@@ -1,14 +1,17 @@
 use bevy::{ prelude::*, render::{ mesh::PrimitiveTopology, render_asset::RenderAssetUsages } };
 use bevy_logic::prelude::*;
 
-use crate::{ helpers::*, triangulation::* };
+use crate::{ camera_rig::UiWorldPosition, helpers::*, triangulation::* };
 
 pub fn gizmo_wires(
     mut gizmos: Gizmos,
     query_wires: Query<(&Wire, &Signal)>,
-    query_fans: Query<(&GlobalTransform, &Signal), (With<GateFan>, Without<Wire>)>
+    query_fans: Query<
+        (&Signal, &GlobalTransform, Option<&UiWorldPosition>),
+        (With<GateFan>, Without<Wire>)
+    >
 ) {
-    for (gt, signal) in query_fans.iter() {
+    for (signal, gt, maybe_ui_pos) in query_fans.iter() {
         gizmos.circle(gt.translation(), Direction3d::Z, 0.08, if signal.is_truthy() {
             Color::GREEN
         } else {
@@ -17,10 +20,14 @@ pub fn gizmo_wires(
     }
 
     for (wire, signal) in query_wires.iter() {
-        let Ok(from) = query_fans.get(wire.from).map(|(t, _)| t.translation()) else {
+        let Ok(from) = query_fans.get(wire.from).map(|(_, t, maybe_ui_pos)| {
+            if let Some(ui_pos) = maybe_ui_pos { ui_pos.0 } else { t.translation() }
+        }) else {
             continue;
         };
-        let Ok(to) = query_fans.get(wire.to).map(|(t, _)| t.translation()) else {
+        let Ok(to) = query_fans.get(wire.to).map(|(_, t, maybe_ui_pos)| {
+            if let Some(ui_pos) = maybe_ui_pos { ui_pos.0 } else { t.translation() }
+        }) else {
             continue;
         };
 

--- a/src/components.rs
+++ b/src/components.rs
@@ -4,14 +4,34 @@ use derive_new::new;
 use crate::logic::signal::Signal;
 
 pub mod prelude {
-    pub use super::{ LogicGateFans, GateInput, GateOutput, InputBundle, OutputBundle };
+    pub use super::{
+        Wire,
+        WireBundle,
+        LogicGateFans,
+        GateFan,
+        GateInput,
+        GateOutput,
+        InputBundle,
+        OutputBundle,
+        NoEvalOutput,
+    };
 }
 
-/// A connection between two nodes.
+/// A component that connects two logic gates with the entity IDs
+/// of their child fans.
 #[derive(new, Component, Clone, Copy, Debug, Reflect)]
 pub struct Wire {
+    /// The [`GateOutput`] entity.
     pub from: Entity,
+    /// The [`GateInput`] entity.
     pub to: Entity,
+}
+
+/// A bundle used to create a wire between a [`GateOutput`] and [`GateInput`].
+#[derive(Bundle, Clone, Copy)]
+pub struct WireBundle {
+    pub wire: Wire,
+    pub signal: Signal,
 }
 
 /// Marks an entity as a logic gate entity, and stores the
@@ -119,6 +139,19 @@ pub struct GateOutput {
     /// Holds [Entity] ids to outgoing wires.
     pub wires: EntityHashSet,
 }
+
+/// Marks an entity as an output that does not require
+/// evaluation. If the entity includes an [`OutputBundle`],
+/// it's [`Signal`] will be propagated to all connected wires
+/// when changed.
+///
+/// This is useful for "gates" that do not have any inputs,
+/// such as buttons and interactive gameplay elements that can
+/// ONLY output a signal.
+///
+/// See the `advanced_gates` example.
+#[derive(Component, Default)]
+pub struct NoEvalOutput;
 
 /// A bundle that can be used to create a child
 /// **input** node of a logic gate entity.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,13 @@ impl Plugin for LogicSimulationPlugin {
         app.add_plugins((LogicSchedulePlugin, LogicReflectPlugin, LogicGatePlugin))
             .insert_resource(Time::<LogicStep>::from_seconds(0.5))
             .init_resource::<LogicGraph>()
-            .add_systems(LogicUpdate, systems::step_logic.in_set(LogicSystemSet::StepLogic));
+            .add_systems(
+                LogicUpdate,
+                (
+                    systems::no_eval_output.in_set(LogicSystemSet::PropagateNoEval),
+                    systems::step_logic.in_set(LogicSystemSet::StepLogic),
+                ).chain()
+            );
     }
 }
 

--- a/src/logic/schedule.rs
+++ b/src/logic/schedule.rs
@@ -9,8 +9,8 @@ pub mod prelude {
 
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum LogicSystemSet {
-    /// Reads [`LogicEvent`] events and updates the [`LogicGraph`] resource.
-    SyncGraph,
+    /// Propagate changed signals that do not require evaluation.
+    PropagateNoEval,
     /// Evaluates the [`LogicGraph`] resource and updates all entities in a single step.
     StepLogic,
 }
@@ -27,14 +27,17 @@ impl Plugin for LogicSchedulePlugin {
     fn build(&self, app: &mut App) {
         app.init_schedule(LogicUpdate).add_systems(FixedMain, run_fixed_main_schedule);
 
-        app.configure_sets(Update, (LogicSystemSet::SyncGraph, LogicSystemSet::StepLogic).chain())
+        app.configure_sets(
+            Update,
+            (LogicSystemSet::PropagateNoEval, LogicSystemSet::StepLogic).chain()
+        )
             .configure_sets(
                 FixedUpdate,
-                (LogicSystemSet::SyncGraph, LogicSystemSet::StepLogic).chain()
+                (LogicSystemSet::PropagateNoEval, LogicSystemSet::StepLogic).chain()
             )
             .configure_sets(
                 LogicUpdate,
-                (LogicSystemSet::SyncGraph, LogicSystemSet::StepLogic).chain()
+                (LogicSystemSet::PropagateNoEval, LogicSystemSet::StepLogic).chain()
             );
     }
 }

--- a/src/logic/signal.rs
+++ b/src/logic/signal.rs
@@ -48,9 +48,58 @@ impl Signal {
         *self = Signal::ON;
     }
 
-    /// Replace self with a new signal.
+    /// Replace self with a new signal if the new signal is not equal.
+    ///
+    /// This is useful for preventing unnecessary changes from triggering
+    /// bevy's change detection.
     pub fn replace(&mut self, new: Self) {
-        *self = new;
+        if new != *self {
+            *self = new;
+        }
+    }
+
+    /// Returns true if the signal is "truthy", [`Analog`] and negative.
+    ///
+    /// [`Analog`]: Signal::Analog
+    pub fn is_sign_negative(&self) -> bool {
+        match self {
+            Self::Analog(value) => value.is_sign_negative(),
+            _ => false,
+        }
+    }
+
+    /// Returns true if the signal is "truthy", [`Analog`] and positive
+    ///
+    /// [`Analog`]: Signal::Analog
+    pub fn is_sign_positive(&self) -> bool {
+        match self {
+            Self::Analog(value) => value.is_sign_positive(),
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if the signal is [`Analog`].
+    ///
+    /// [`Analog`]: Signal::Analog
+    #[must_use]
+    pub fn is_analog(&self) -> bool {
+        matches!(self, Self::Analog(..))
+    }
+
+    /// Returns `true` if the signal is [`Digital`].
+    ///
+    /// [`Digital`]: Signal::Digital
+    #[must_use]
+    pub fn is_digital(&self) -> bool {
+        matches!(self, Self::Digital(..))
+    }
+
+    /// Returns `true` if the signal is [`Undefined`].
+    ///
+    /// [`Undefined`]: Signal::Undefined
+    #[must_use]
+    pub fn is_undefined(&self) -> bool {
+        matches!(self, Self::Undefined)
     }
 }
 

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -6,7 +6,8 @@ pub mod prelude {
     pub use super::LogicGraph;
 }
 
-/// A resources that stores logic gates' graph.
+/// The logic graph resource determines the order
+/// logic gates are evaluated in.
 #[derive(Resource, Default, Reflect)]
 pub struct LogicGraph {
     #[reflect(ignore)]


### PR DESCRIPTION
This introduces a new `NoEvalOutput` marker component that opts-in a `GateOutput` to have its `Signal` immediately propagated through connected wires.

I've also updated the `advanced_gates` example to act as a proper "lock box" or permutational keypad. 

The example now demonstrates how to hold onto player-interactions until they have been evaluated by the logic step system.