### PR TITLE
Refactor OR gates to output their max abs input signal by default.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_logic"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bevy",
  "bevy-inspector-egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_logic"
 description = "A logic gate simulation plugin for Bevy."
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Jacob Bergholtz"]
 homepage = "https://github.com/cuppachino/bevy_logic"
 repository = "https://github.com/cuppachino/bevy_logic"

--- a/examples/advanced_gates/main.rs
+++ b/examples/advanced_gates/main.rs
@@ -556,7 +556,7 @@ mod helpers {
         commands
             .spawn_gate((
                 Name::new("AND"),
-                AndGate,
+                AndGate::default(),
                 pbr(position.extend(0.0), meshes.add(build_mesh(inputs, 1, 0)), materials),
             ))
             .build_inputs(inputs, fan_entity_mut(GateFan::Input, inputs))

--- a/examples/advanced_gates/visual.rs
+++ b/examples/advanced_gates/visual.rs
@@ -11,7 +11,7 @@ pub fn gizmo_wires(
         (With<GateFan>, Without<Wire>)
     >
 ) {
-    for (signal, gt, maybe_ui_pos) in query_fans.iter() {
+    for (signal, gt, _) in query_fans.iter() {
         gizmos.circle(gt.translation(), Direction3d::Z, 0.08, if signal.is_truthy() {
             Color::GREEN
         } else {

--- a/examples/cycles/main.rs
+++ b/examples/cycles/main.rs
@@ -53,13 +53,13 @@ fn setup(world: &mut World) {
         .insert_bundle(not_bundle_b)
         .build();
     let and_gate_a = world
-        .spawn_gate((Name::new("AND"), AndGate))
+        .spawn_gate((Name::new("AND"), AndGate::default()))
         .build_inputs(2, gate_fan(GateFan::Input, 2, 1.0))
         .build_outputs(1, gate_fan(GateFan::Output, 1, 1.0))
         .insert_bundle(and_bundle_a.clone())
         .build();
     let and_gate_b = world
-        .spawn_gate((Name::new("AND"), AndGate))
+        .spawn_gate((Name::new("AND"), AndGate::default()))
         .build_inputs(2, gate_fan(GateFan::Input, 2, 1.0))
         .build_outputs(1, gate_fan(GateFan::Output, 1, 1.0))
         .insert_bundle(and_bundle_b)

--- a/src/logic/gates.rs
+++ b/src/logic/gates.rs
@@ -69,6 +69,8 @@ impl LogicGate for Battery {
 
 /// An AND gate emits a signal if all inputs are true.
 ///
+/// - If `invert_output` is true, the gate act as a NAND gate instead.
+///
 /// ```md
 /// Truth table:
 /// | A | B | Q |
@@ -78,12 +80,19 @@ impl LogicGate for Battery {
 /// | 1 | 0 | 0 |
 /// | 1 | 1 | 1 |
 /// ```
-#[derive(Component, Clone, Copy, Debug, Reflect)]
-pub struct AndGate;
+#[derive(Component, Clone, Copy, Debug, Default, Reflect)]
+pub struct AndGate {
+    pub invert_output: bool,
+}
+
+impl AndGate {
+    pub const NAND: AndGate = AndGate { invert_output: true };
+}
 
 impl LogicGate for AndGate {
     fn evaluate(&mut self, inputs: &[Signal], outputs: &mut [Signal]) {
         let signal: Signal = inputs.iter().all(Signal::is_truthy).into();
+        let signal = if self.invert_output { !signal } else { signal };
         outputs.set_all(signal);
     }
 }
@@ -97,7 +106,7 @@ impl LogicGate for AndGate {
 /// | 0 | 1 |
 /// | 1 | 0 |
 /// ```
-#[derive(Component, Clone, Copy, Debug, Reflect)]
+#[derive(Component, Clone, Copy, Debug, Default, Reflect)]
 pub struct NotGate;
 
 impl LogicGate for NotGate {

--- a/src/logic/gates.rs
+++ b/src/logic/gates.rs
@@ -107,19 +107,21 @@ impl LogicGate for NotGate {
     }
 }
 
-/// An OR gate emits a signal if any input is true.
+/// An OR gate emits the absolute maximum of its input signals.
 ///
 /// - If `invert_output` is true, the gate will be a NOR gate instead.
 /// - If `is_adder` is true, the gate will act as an analog adder.
 ///
 /// ```md
 /// Truth table:
-/// | A | B | Q |
-/// |---|---|---|
-/// | 0 | 0 | 0 |
-/// | 0 | 1 | 1 |
-/// | 1 | 0 | 1 |
-/// | 1 | 1 | 1 |
+/// | A  | B  | Q  |
+/// |----|----|----|
+/// |  0 |  0 |  0 |
+/// |  0 |  1 |  1 |
+/// |  1 |  0 |  1 |
+/// |  1 |  1 |  1 |
+/// | -1 |  1 | -1 |
+/// |  1 | -1 |  1 |
 /// ```
 #[derive(Component, Clone, Copy, Debug, Default, Reflect)]
 pub struct OrGate {
@@ -138,7 +140,7 @@ impl LogicGate for OrGate {
         let signal = if self.is_adder {
             inputs.iter().fold(Signal::OFF, |acc, input| { acc + *input })
         } else {
-            inputs.iter().any(Signal::is_truthy).into()
+            inputs.iter().fold(Signal::OFF, |acc, s| { acc.max_abs(*s) })
         };
 
         let signal = if self.invert_output { !signal } else { signal };

--- a/src/logic/signal.rs
+++ b/src/logic/signal.rs
@@ -110,7 +110,7 @@ impl Signal {
         match (self, other) {
             // Analog cmp Analog
             (Signal::Analog(a), Signal::Analog(b)) => {
-                if a.abs() > b.abs() { Signal::Analog(a) } else { Signal::Analog(b) }
+                if a.abs() >= b.abs() { Signal::Analog(a) } else { Signal::Analog(b) }
             }
             // Analog cmp Digital
             (Signal::Analog(a), Signal::OFF) | (Signal::OFF, Signal::Analog(a)) => {

--- a/src/logic/signal.rs
+++ b/src/logic/signal.rs
@@ -101,6 +101,33 @@ impl Signal {
     pub fn is_undefined(&self) -> bool {
         matches!(self, Self::Undefined)
     }
+
+    /// Compare two signals and return the signal with a greater
+    /// absolute value.
+    ///
+    /// This is useful when negative signals should hold the same weight as positive signals.
+    pub fn max_abs(self, other: Signal) -> Signal {
+        match (self, other) {
+            // Analog cmp Analog
+            (Signal::Analog(a), Signal::Analog(b)) => {
+                if a.abs() > b.abs() { Signal::Analog(a) } else { Signal::Analog(b) }
+            }
+            // Analog cmp Digital
+            (Signal::Analog(a), Signal::OFF) | (Signal::OFF, Signal::Analog(a)) => {
+                if a.is_normal() { Signal::Analog(a) } else { Signal::OFF }
+            }
+            (Signal::Analog(a), Signal::ON) | (Signal::ON, Signal::Analog(a)) => {
+                if a.abs() >= 1.0 { Signal::Analog(a) } else { Signal::ON }
+            }
+            // Digital cmp Digital
+            (Signal::OFF, Signal::OFF) => Signal::OFF,
+            (Signal::ON, Signal::ON) | (Signal::ON, Signal::OFF) | (Signal::OFF, Signal::ON) => {
+                Signal::ON
+            }
+            // Undefined
+            (Signal::Undefined, v) | (v, Signal::Undefined) => v,
+        }
+    }
 }
 
 impl std::ops::Add for Signal {


### PR DESCRIPTION
Previously, OR gates would emit `Signal::Digital(true)` if *any* input was "truthy". 

This PR refactors OR gates to output the maximum input signal. Since analog signals can be negative, we compare them via their absolute value. This gives equal weight to negative and positive signals.

Feedback loops are a first-class feature of `bevy_logic` and its important that the few gates provided "out of the box" take advantage of them.