### PR TITLE
fix: time is faster for unfocused windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,30 +621,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_eventlistener"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d65c75b4f81818cacdc8a4302c5413910c5fb7727564deaf95e56e0dea4bd0"
-dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_eventlistener_derive",
- "bevy_hierarchy",
- "bevy_utils",
-]
-
-[[package]]
-name = "bevy_eventlistener_derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa29be733a02a5d7ca4507ef15f294711c1a0884b9a9a2730640ff4e7d0200ab"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.58",
-]
-
-[[package]]
 name = "bevy_gilrs"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,12 +787,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_logic"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "bevy",
  "bevy-inspector-egui",
  "bevy-trait-query",
- "bevy_mod_picking",
  "derive-new",
  "derive_more",
  "i_float",
@@ -860,54 +835,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_mod_picking"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79f17a34025d95e2e3525207ec73090647c6f40c3136fc674f87e167a9ae6be"
-dependencies = [
- "bevy_app",
- "bevy_core",
- "bevy_core_pipeline",
- "bevy_ecs",
- "bevy_eventlistener",
- "bevy_math",
- "bevy_picking_core",
- "bevy_picking_highlight",
- "bevy_picking_input",
- "bevy_picking_raycast",
- "bevy_picking_selection",
- "bevy_picking_sprite",
- "bevy_picking_ui",
- "bevy_reflect",
- "bevy_render",
- "bevy_text",
- "bevy_ui",
- "bevy_utils",
- "bevy_window",
-]
-
-[[package]]
-name = "bevy_mod_raycast"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca646aeaab4a170e1f3e8284b925e2f990eb18616e95d7826c873c8e26ee945"
-dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_derive",
- "bevy_ecs",
- "bevy_gizmos",
- "bevy_math",
- "bevy_reflect",
- "bevy_render",
- "bevy_sprite",
- "bevy_transform",
- "bevy_utils",
- "bevy_window",
- "crossbeam-channel",
-]
-
-[[package]]
 name = "bevy_pbr"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,126 +857,6 @@ dependencies = [
  "radsort",
  "smallvec",
  "thread_local",
-]
-
-[[package]]
-name = "bevy_picking_core"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c8cdca408508a7d006bf077c6cbb6660a65895323333f206b7cce7b801a8e2"
-dependencies = [
- "bevy_app",
- "bevy_derive",
- "bevy_ecs",
- "bevy_eventlistener",
- "bevy_math",
- "bevy_reflect",
- "bevy_render",
- "bevy_transform",
- "bevy_utils",
- "bevy_window",
-]
-
-[[package]]
-name = "bevy_picking_highlight"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e684569b5f7dae06d1ff66e2287cee808b3862d9ae0d01dbe114d7d199d40cfd"
-dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_ecs",
- "bevy_pbr",
- "bevy_picking_core",
- "bevy_picking_selection",
- "bevy_reflect",
- "bevy_render",
- "bevy_sprite",
-]
-
-[[package]]
-name = "bevy_picking_input"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60182209f48943de6c8bc3305a70f52012a18ef26f92f460f9436441b8badf0b"
-dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_hierarchy",
- "bevy_input",
- "bevy_math",
- "bevy_picking_core",
- "bevy_picking_selection",
- "bevy_reflect",
- "bevy_render",
- "bevy_utils",
- "bevy_window",
-]
-
-[[package]]
-name = "bevy_picking_raycast"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2677d0a3402fea3327a216649c104f969685a5c01d969d274c89facba86c164d"
-dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_mod_raycast",
- "bevy_picking_core",
- "bevy_reflect",
- "bevy_render",
- "bevy_transform",
- "bevy_window",
-]
-
-[[package]]
-name = "bevy_picking_selection"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc986eefd38058918322418d1e6ae398e74d48730e623a55dc20be78d5ee24b"
-dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_eventlistener",
- "bevy_input",
- "bevy_picking_core",
- "bevy_reflect",
- "bevy_utils",
-]
-
-[[package]]
-name = "bevy_picking_sprite"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac5309026e8c7f5aed2afec3aa2f21fb0a0487e9bb3d851860377891459df75"
-dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_ecs",
- "bevy_math",
- "bevy_picking_core",
- "bevy_render",
- "bevy_sprite",
- "bevy_transform",
- "bevy_window",
-]
-
-[[package]]
-name = "bevy_picking_ui"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ad6d40e33203115af38adc984341cf5637911baa940028b6a43a9917d64e79"
-dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_hierarchy",
- "bevy_math",
- "bevy_picking_core",
- "bevy_render",
- "bevy_transform",
- "bevy_ui",
- "bevy_utils",
- "bevy_window",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_logic"
 description = "A logic gate simulation plugin for Bevy."
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Jacob Bergholtz"]
 homepage = "https://github.com/cuppachino/bevy_logic"
 repository = "https://github.com/cuppachino/bevy_logic"
@@ -23,7 +23,6 @@ derive_more = "0.99.17"
 [dev-dependencies]
 bevy = "0.13.2"
 bevy-inspector-egui = "0.24"
-bevy_mod_picking = "0.18.2"
 leafwing-input-manager = "0.13.3"
 itertools = "0.12.1"
 i_float = "0.10.0"

--- a/examples/cycles/main.rs
+++ b/examples/cycles/main.rs
@@ -18,6 +18,7 @@ fn main() {
     app.add_plugins((DefaultPlugins, WorldInspectorPlugin::new(), CameraRigPlugin, VisualPlugin))
         .insert_resource(ClearColor(Color::rgba_linear(0.22, 0.402, 0.598, 1.0)))
         .add_plugins(LogicSimulationPlugin::default())
+        .insert_resource(Time::<Fixed>::from_seconds(1.0)) // Just to demonstrate Fixed steps independent of LogicStep.
         .add_systems(Startup, setup)
         .run();
 }

--- a/src/logic/schedule.rs
+++ b/src/logic/schedule.rs
@@ -23,12 +23,15 @@ pub enum LogicSystemSet {
 /// This works just like bevy's [`FixedUpdate`] schedule. The speed of the simulation
 /// can be controlled by inserting a [`Time<LogicStep>`] resource.
 ///
-/// See [`FixedMain`] for more information.
+/// See [`FixedMain`] and [`bevy::app::RunFixedMainLoop`] for more information.
 pub struct LogicSchedulePlugin;
 
 impl Plugin for LogicSchedulePlugin {
     fn build(&self, app: &mut App) {
-        app.init_schedule(LogicUpdate).add_systems(FixedMain, run_fixed_main_schedule);
+        app.init_schedule(LogicUpdate).add_systems(
+            bevy::app::RunFixedMainLoop,
+            run_fixed_main_schedule
+        );
 
         app.configure_sets(
             Update,


### PR DESCRIPTION
This fixes a major issue with the run `LogicStep` loop.

See https://github.com/bevyengine/bevy/issues/13070 for more information.